### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java


### PR DESCRIPTION
Travis CI allows to detect build errors.

The build currently fails which I could reproduce locally as well, see https://travis-ci.org/krichter722/texlipse/builds/386282908 for details.

Since Travis CI has already been activated, but only started working with this script and fails, it might be necessary to fix the build issues and rebasing this PR on them before being able to merge it.