### PR TITLE
Fix #47: Remove --src-specials from xelatex default arguments

### DIFF
--- a/org.eclipse.texlipse/source/org/eclipse/texlipse/builder/LatexRunner.java
+++ b/org.eclipse.texlipse/source/org/eclipse/texlipse/builder/LatexRunner.java
@@ -60,7 +60,7 @@ public class LatexRunner extends AbstractProgramRunner {
     }
     
     public String getDefaultArguments() {
-        return "-interaction=nonstopmode --src-specials %input";
+        return "-interaction=nonstopmode %input";
     }
     
     public String getInputFormat() {


### PR DESCRIPTION
Task-Url: https://github.com/eclipse/texlipse/issues/47