### PR TITLE
Fix Bibtex editor in Eclipse 2020-09

### DIFF
--- a/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibBraceRule.java
+++ b/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibBraceRule.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.texlipse.bibeditor;
 
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;

--- a/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibCommandRule.java
+++ b/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibCommandRule.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.texlipse.bibeditor;
 
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IRule;
 import org.eclipse.jface.text.rules.IToken;

--- a/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibEntryScanner.java
+++ b/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibEntryScanner.java
@@ -13,7 +13,7 @@ package org.eclipse.texlipse.bibeditor;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IRule;

--- a/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibStringRule.java
+++ b/org.eclipse.texlipse/source/org/eclipse/texlipse/bibeditor/BibStringRule.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.texlipse.bibeditor;
 
-import org.eclipse.jface.text.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;


### PR DESCRIPTION
org.eclipse.jface.text.Assert appears to have been removed in Eclipse 2020-09,
which caused the Bibtex editor not to open properly.

This commit switches to org.eclipse.core.runtime.Assert.

Solves issue #86 