### PR TITLE
Try to fix the CI build

### DIFF
--- a/org.eclipse.texlipse/pom.xml
+++ b/org.eclipse.texlipse/pom.xml
@@ -40,7 +40,7 @@
 	<repositories>
 		<repository>
 		<id>cogcomp</id>
-		<url>http://cogcomp.org/m2repo/</url>
+		<url>https://cogcomp.seas.upenn.edu/m2repo/</url>
 	 </repository>
 	</repositories>
 


### PR DESCRIPTION
I believe https://ci.eclipse.org/texlipse/job/nightly/ fails because HTTP is forbidden and the repository is redirecting.