### PR TITLE
[#107] Repair maven build for Maven 3.9.4 on Java 17

### DIFF
--- a/default.target
+++ b/default.target
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse TeXlipse Target Platform" sequenceNumber="1573198533">
+<target name="Eclipse TeXlipse Target Platform" sequenceNumber="1706890183">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.13.0.v20190916-1323"/>
-      <repository location="http://download.eclipse.org/releases/2019-09/"/>
+      <repository location="https://download.eclipse.org/releases/2019-09/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
-      <repository location="http://download.eclipse.org/cbi/updates/license"/>
+      <repository location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
   </locations>
 </target>

--- a/default.tpd
+++ b/default.tpd
@@ -1,8 +1,8 @@
 target "Eclipse TeXlipse Target Platform" with source requirements
 
-location "http://download.eclipse.org/releases/2019-09/" {
+location "https://download.eclipse.org/releases/2019-09/" {
     org.eclipse.sdk.feature.group
 }
-location "http://download.eclipse.org/cbi/updates/license" {
+location "https://download.eclipse.org/cbi/updates/license" {
 	org.eclipse.license.feature.group
 }

--- a/org.eclipse.texlipse/pom.xml
+++ b/org.eclipse.texlipse/pom.xml
@@ -40,7 +40,7 @@
 	<repositories>
 		<repository>
 		<id>cogcomp</id>
-		<url>http://cogcomp.org/m2repo/</url>
+		<url>https://cogcomp.org/m2repo/</url>
 	 </repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<version>2.0.3-SNAPSHOT</version>
 	
 	<properties>
-		<tycho.version>1.5.1</tycho.version>
+		<tycho.version>2.7.5</tycho.version>
 		<tycho.scmUrl>scm:git:git://github.com/eclipse/texlipse.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
* Use `https` instead of `http`
* Upgrade to Tycho 2.7.5

Fixes #107 